### PR TITLE
Discriminate between http requests vs https.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wm_okta_helper (0.2.0)
+    wm_okta_helper (0.2.3)
       json-jwt
       jwt
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     wm_okta_helper (0.2.3)
+      addressable
       json-jwt
       jwt
 

--- a/lib/wm_okta_helper/post_request.rb
+++ b/lib/wm_okta_helper/post_request.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'addressable/uri'
 require 'net/http'
 require 'uri'
 
@@ -8,29 +9,63 @@ module WmOktaHelper
     def initialize(options)
       @request_body = options[:request_body]
       @url = options[:url]
+      @schemes = %w[http https].freeze
     end
 
     def call
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      return invalid_url unless valid_url?(url)
+      post_request
+    end
 
+    protected
+
+    def post_request
+      http = Net::HTTP.new(uri.host, uri.port)
+      open_ssl(http) if parsed.scheme == 'https'
+
+      response = http.request(request_configuration)
+      JSON.parse(response.read_body)
+    end
+
+    def uri
+      URI(url)
+    end
+
+    def request_configuration
       request = Net::HTTP::Post.new(uri)
       request['Accept'] = 'application/json'
       request['Content-Type'] = 'application/json'
       request['Cache-Control'] = 'no-cache'
       request.body = request_body.to_json
-
-      response = http.request(request)
-      JSON.parse(response.read_body)
+      request
     end
 
-    attr_accessor :request_body, :url
-
-    private
-
-    def uri
-      URI(url)
+    def parsed
+      Addressable::URI.parse(uri) or return false
     end
+
+    def valid_url?(parsed)
+      schemes.include?(
+        parsed.scan(URI::DEFAULT_PARSER.make_regexp)[0][0]
+      )
+    rescue Addressable::URI::InvalidURIError
+      false
+    end
+
+    def invalid_url
+      {
+        "errors": [
+          "The url #{url} is not valid"
+        ]
+      }
+    end
+
+    def open_ssl(http)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http
+    end
+
+    attr_accessor :request_body, :url, :schemes
   end
 end

--- a/lib/wm_okta_helper/version.rb
+++ b/lib/wm_okta_helper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WmOktaHelper
-  VERSION = '0.2.1'
+  VERSION = '0.2.3'
 end

--- a/spec/lib/wm_okta_helper/post_request_spec.rb
+++ b/spec/lib/wm_okta_helper/post_request_spec.rb
@@ -2,6 +2,16 @@
 
 RSpec.describe WmOktaHelper::PostRequest do
   describe '#call' do
+    let(:response_headers) do
+      {
+        'Accept' => 'application/json',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Cache-Control' => 'no-cache',
+        'Content-Type' => 'application/json',
+        'Host' => 'westernmilling.okta.com',
+        'User-Agent' => 'Ruby'
+      }
+    end
     context 'with correct credentials' do
       let(:request_body) do
         ''
@@ -22,15 +32,15 @@ RSpec.describe WmOktaHelper::PostRequest do
           'status' => 'SUCCESS',
           'sessionToken' => 'a_long_token',
           '_embedded' =>
-  { 'user' =>
-    { 'id' => '00u1b364ylUITlaQ22p7',
-      'profile' =>
-      {
-        'login' => 'jfernandez@westernmilling.com',
-        'firstName' => 'Jose',
-        'lastName' => 'Fernandez', 'locale' => 'en',
-        'timeZone' => 'America/Los_Angeles'
-      } } } }.to_json
+          { 'user' =>
+            { 'id' => '00u1b364ylUITlaQ22p7',
+              'profile' =>
+              {
+                'login' => 'jfernandez@westernmilling.com',
+                'firstName' => 'Jose',
+                'lastName' => 'Fernandez', 'locale' => 'en',
+                'timeZone' => 'America/Los_Angeles'
+              } } } }.to_json
       end
 
       it 'returns expected message hash' do
@@ -39,21 +49,51 @@ RSpec.describe WmOktaHelper::PostRequest do
         )
           .with(
             body: '""',
-            headers: {
-              'Accept' => 'application/json',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'Cache-Control' => 'no-cache',
-              'Content-Type' => 'application/json',
-              'Host' => 'westernmilling.okta.com',
-              'User-Agent' => 'Ruby'
-            }
+            headers: response_headers
           )
           .to_return(status: 200, body: response_body, headers: {})
 
         expect(subject['sessionToken']).to_not be_empty
       end
     end
+
     context 'with incorrect credentials' do
+      let(:request_body) do
+        ''
+      end
+      let(:url) do
+        'https://westernmilling.okta.com/api/v1/authn'
+      end
+
+      let(:subject) do
+        WmOktaHelper::PostRequest.new(
+          request_body: request_body,
+          url: url
+        ).call
+      end
+
+      let(:response_body) do
+        {
+          'errors' => [{
+            'title' => 'Not Authorized'
+          }]
+        }.to_json
+      end
+
+      it 'returns an error' do
+        stub_request(
+          :post, 'https://westernmilling.okta.com/api/v1/authn'
+        )
+          .with(
+            body: '""',
+            headers: response_headers
+          )
+          .to_return(status: 401, body: response_body, headers: {})
+
+        errors = JSON.parse(response_body)['errors']
+        expect(subject['sessionToken']).to be_nil
+        expect(errors.first['title']).to eq 'Not Authorized'
+      end
     end
   end
 end

--- a/wm_okta_helper.gemspec
+++ b/wm_okta_helper.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'addressable'
   spec.add_dependency 'json-jwt'
   spec.add_dependency 'jwt'
 


### PR DESCRIPTION
Wm-okta-helper needs to be able to discriminate between http requests vs https.
Needed-by: #11 and  [wm-mssql-wrapper/issues/5](https://github.com/westernmilling/wm-mssql-wrapper/issues/5)